### PR TITLE
Added specifying of Success/Fail redirect method

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -108,6 +108,74 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     }
 
     /**
+     * Get the return method.
+     *
+     * @return string return method
+     */
+    public function getReturnMethod()
+    {
+        return $this->formatMethod($this->getParameter('returnMethod'));
+    }
+
+    /**
+     * Set the return method.
+     *
+     * @param string $value return method
+     *
+     * @return self
+     */
+    public function setReturnMethod($value)
+    {
+        return $this->setParameter('returnMethod', $value);
+    }
+
+    /**
+     * Get the cancel method.
+     *
+     * @return string cancel method
+     */
+    public function getCancelMethod()
+    {
+        return $this->formatMethod($this->getParameter('cancelMethod'));
+    }
+
+    /**
+     * Set the cancel method.
+     *
+     * @param string $value cancel method
+     *
+     * @return self
+     */
+    public function setCancelMethod($value)
+    {
+        return $this->setParameter('cancelMethod', $value);
+    }
+
+    /**
+     * Redirect method conversion table.
+     */
+    private static $_methods = [
+        '1'     => '1',
+        '2'     => '2',
+        'GET'   => '0',
+        'POST'  => '1',
+        'LINK'  => '2',
+    ];
+
+    /**
+     * Converts redirect method to WebMoney code: 0, 1 or 2.
+     *
+     * @param string $method
+     *
+     * @return string
+     */
+    public function formatMethod($method)
+    {
+        $method = strtoupper((string)$method);
+        return isset(self::$_methods[$method]) ? self::$_methods[$method] : '0';
+    }
+
+    /**
      * Get the SSL file.
      *
      * This certificate will be used for the payout request.

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -154,7 +154,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     /**
      * Redirect method conversion table.
      */
-    private static $_methods = [
+    private static $methodsTable = [
         '1'     => '1',
         '2'     => '2',
         'GET'   => '0',
@@ -172,7 +172,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     public function formatMethod($method)
     {
         $method = strtoupper((string)$method);
-        return isset(self::$_methods[$method]) ? self::$_methods[$method] : '0';
+        return isset(self::$methodsTable[$method]) ? self::$methodsTable[$method] : '0';
     }
 
     /**

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -154,13 +154,13 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     /**
      * Redirect method conversion table.
      */
-    private static $methodsTable = [
+    private static $methodsTable = array(
         '1'     => '1',
         '2'     => '2',
         'GET'   => '0',
         'POST'  => '1',
         'LINK'  => '2',
-    ];
+    );
 
     /**
      * Converts redirect method to WebMoney code: 0, 1 or 2.

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -39,9 +39,9 @@ class PurchaseRequest extends AbstractRequest
             'LMI_SIM_MODE' => $this->getTestMode() ? '2' : '0',
             'LMI_RESULT_URL' => $this->getNotifyUrl(),
             'LMI_SUCCESS_URL' => $this->getReturnUrl(),
-            'LMI_SUCCESS_METHOD' => '0',
+            'LMI_SUCCESS_METHOD' => $this->getReturnMethod(),
             'LMI_FAIL_URL' => $this->getCancelUrl(),
-            'LMI_FAIL_METHOD' => '0',
+            'LMI_FAIL_METHOD' => $this->getCancelMethod(),
         );
     }
 

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -18,6 +18,8 @@ class PurchaseRequestTest extends TestCase
             'returnUrl' => 'https://www.foodstore.com/success',
             'cancelUrl' => 'https://www.foodstore.com/failure',
             'notifyUrl' => 'https://www.foodstore.com/notify',
+            'returnMethod' => 'POST',
+            'cancelMethod' => 'link',
             'description' => 'Test Transaction',
             'transactionId' => '1234567890',
             'amount' => '14.65',
@@ -48,9 +50,9 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('2', $data['LMI_SIM_MODE']);
         $this->assertSame('https://www.foodstore.com/notify', $data['LMI_RESULT_URL']);
         $this->assertSame('https://www.foodstore.com/success', $data['LMI_SUCCESS_URL']);
-        $this->assertSame('0', $data['LMI_SUCCESS_METHOD']);
+        $this->assertSame('1', $data['LMI_SUCCESS_METHOD']);
         $this->assertSame('https://www.foodstore.com/failure', $data['LMI_FAIL_URL']);
-        $this->assertSame('0', $data['LMI_FAIL_METHOD']);
+        $this->assertSame('2', $data['LMI_FAIL_METHOD']);
     }
 
     public function testSendData()


### PR DESCRIPTION
Your lib is done really nice :)
What we really miss is the ability to set Success/Fail method to POST.
Hope you'll accept this pull request.
If you're ok with the proposed code I can add tests for it.
