### PR TITLE
Added CompletePurchaseResponse::getCurrency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "omnipay/tests": "~2.0",
-        "satooshi/php-coveralls": "dev-master"
+        "satooshi/php-coveralls": "1.0.0"
     },
     "extra": {
         "branch-alias": {

--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -55,6 +55,11 @@ class CompletePurchaseResponse extends AbstractResponse
         return $this->data['LMI_PAYMENT_AMOUNT'];
     }
 
+    public function getCurrency()
+    {
+        return $this->request->getCurrencyByPurse($this->data['LMI_PAYEE_PURSE']);
+    }
+
     public function getTestMode()
     {
         return (bool) $this->getMode();

--- a/tests/Message/CompletePurchaseResponseTest.php
+++ b/tests/Message/CompletePurchaseResponseTest.php
@@ -90,6 +90,7 @@ class CompletePurchaseResponseTest extends TestCase
         $this->assertSame('892', $response->getTransactionReference());
         $this->assertSame('Z123428476799', $response->getMerchantPurse());
         $this->assertSame('14.65', $response->getAmount());
+        $this->assertSame('USD', $response->getCurrency());
         $this->assertTrue($response->getTestMode());
         $this->assertSame('1', $response->getMode());
         $this->assertSame('0B12E75431284D6FCC05D8AF02B90AC28A0788FB95C9FF6B655344022F0746E5', $response->getHash());
@@ -122,6 +123,7 @@ class CompletePurchaseResponseTest extends TestCase
         $this->assertSame('892', $response->getTransactionReference());
         $this->assertSame('Z123428476799', $response->getMerchantPurse());
         $this->assertSame('14.65', $response->getAmount());
+        $this->assertSame('USD', $response->getCurrency());
         $this->assertTrue($response->getTestMode());
         $this->assertSame('1', $response->getMode());
         $this->assertSame('sha256', $response->getHashType());
@@ -155,6 +157,7 @@ class CompletePurchaseResponseTest extends TestCase
         $this->assertSame('892', $response->getTransactionReference());
         $this->assertSame('Z123428476799', $response->getMerchantPurse());
         $this->assertSame('14.65', $response->getAmount());
+        $this->assertSame('USD', $response->getCurrency());
         $this->assertTrue($response->getTestMode());
         $this->assertSame('1', $response->getMode());
         $this->assertSame('md5', $response->getHashType());


### PR DESCRIPTION
Returns currency by the merchant purse provided in the response. 